### PR TITLE
Avoid breaking strings with {{ or }} in it that are not mustache tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function maxstache (str, ctx) {
   assert.equal(typeof str, 'string')
   assert.equal(typeof ctx, 'object')
 
-  const tokens = str.split(/\{\{|\}\}/)
+  const tokens = str.split(/\{\{([^{}]+?)\}\}/)
   const res = tokens.map(parse(ctx))
   return res.join('')
 }

--- a/test.js
+++ b/test.js
@@ -27,6 +27,22 @@ test('should work even if the string starts with a var', function (t) {
   t.equal(res, 'Yoda, my name is')
 })
 
+test('should not modify incomplete curly bracket tags', function (t) {
+  t.plan(2)
+
+  const str = 'This gets changed: {{name}}, and }} after this gets preserved'
+  const ctx = { name: 'Yoda' }
+  const res = maxstache(str, ctx)
+
+  t.equal(res, 'This gets changed: Yoda, and }} after this gets preserved')
+
+  const str2 = 'These brackets are preserved {{bad_tag but {{name}} gets changed'
+  const ctx2 = { name: 'Yoda' }
+  const res2 = maxstache(str2, ctx2)
+
+  t.equal(res2, 'These brackets are preserved {{bad_tag but Yoda gets changed')
+})
+
 test('should work even if two vars are next to each other', function (t) {
   t.plan(1)
 


### PR DESCRIPTION
I recently made a small project with `copy-template-dir` and noticed that one file wasn't being copied over properly. It broke on this line:

```js
parser.addArgument('--log', { help: `Sets console logging level ("${logDefaultLevel}" by default). Choices: {${logLevels.join(',')}}.`, dest: 'logLevel', choices: logLevels, metavar: 'LEVEL', defaultValue: logDefaultLevel })
```

Specifically, the file ended after `.join(',')`. As it turns out, maxstache is splitting on {{ or }}, meaning it also splits on pieces of text that are not full tags.

I've updated the regex so that it requires a tag to be complete: {{, then any string not containing { or }, and then }}. If it's not complete, it will remain preserved as-is. I did not update the version number yet.